### PR TITLE
Update demofilebitbuf.cpp

### DIFF
--- a/src/demofilebitbuf.cpp
+++ b/src/demofilebitbuf.cpp
@@ -688,7 +688,7 @@ void CBitRead::ReadBitAngles( QAngle& fa )
 float CBitRead::ReadBitFloat( void )
 {
 	uint32 nvalue = ReadUBitLong( 32 );
-	float fvalue = (float) nvalue;
+	float fvalue = *reinterpret_cast<float*>(&nvalue);
 	return fvalue;
 }
 


### PR DESCRIPTION
Hey, I saw that when one commit has fixed some warnings for gcc/g++.
The value needs to be reinterpreted, not converted to a float.